### PR TITLE
Added Opella-LD cJTAG support

### DIFF
--- a/src/jtag/core.c
+++ b/src/jtag/core.c
@@ -1992,10 +1992,18 @@ static struct transport jtag_transport = {
 	.init = jtag_init,
 };
 
+static struct transport cjtag_transport = {
+   .name = "cjtag",
+   .select = jtag_select,
+   .init = jtag_init,
+};
+
+
 static void jtag_constructor(void) __attribute__((constructor));
 static void jtag_constructor(void)
 {
 	transport_register(&jtag_transport);
+   transport_register(&cjtag_transport);
 }
 
 /** Returns true if the current debug session
@@ -2003,7 +2011,7 @@ static void jtag_constructor(void)
  */
 bool transport_is_jtag(void)
 {
-	return get_current_transport() == &jtag_transport;
+	return (get_current_transport() == &jtag_transport) || (get_current_transport() == &cjtag_transport);
 }
 
 int adapter_resets(int trst, int srst)

--- a/src/jtag/drivers/mpsse.c
+++ b/src/jtag/drivers/mpsse.c
@@ -954,3 +954,35 @@ error_check:
 
 	return retval;
 }
+
+void mpsse_write(struct mpsse_ctx* ctx, const uint8_t* out, unsigned out_length)
+{
+   unsigned i;
+
+   if (ctx->retval != ERROR_OK) {
+      LOG_ERROR("Ignoring command due to previous error");
+      return;
+   }
+
+   if (buffer_write_space(ctx) < out_length)
+      ctx->retval = mpsse_flush(ctx);
+
+   for (i = 0; i < out_length; i++) {
+      buffer_write_byte(ctx, out[i]);
+   }
+}
+
+void mpsse_read(struct mpsse_ctx* ctx, uint8_t* in, unsigned in_length)
+{
+   if (ctx->retval != ERROR_OK) {
+      LOG_ERROR("Ignoring command due to previous error");
+      return;
+   }
+
+   if (buffer_read_space(ctx) < in_length)
+      ctx->retval = mpsse_flush(ctx);
+
+   buffer_add_read(ctx, in, 0, in_length * 8, 0);
+   /* Flush any existing commands... */
+   mpsse_flush(ctx);
+}

--- a/src/jtag/drivers/mpsse.h
+++ b/src/jtag/drivers/mpsse.h
@@ -74,5 +74,7 @@ int mpsse_set_frequency(struct mpsse_ctx *ctx, int frequency);
 /* Queue handling */
 int mpsse_flush(struct mpsse_ctx *ctx);
 void mpsse_purge(struct mpsse_ctx *ctx);
+void mpsse_write(struct mpsse_ctx* ctx, const uint8_t* out, unsigned out_length);
+void mpsse_read(struct mpsse_ctx* ctx, uint8_t* in, unsigned in_length);
 
 #endif /* OPENOCD_JTAG_DRIVERS_MPSSE_H */

--- a/tcl/interface/ftdi/ashling-opella-ld-jtag.cfg
+++ b/tcl/interface/ftdi/ashling-opella-ld-jtag.cfg
@@ -1,0 +1,21 @@
+#
+# Ashling Opella-LD
+#
+# https://www.ashling.com/Opella-LD/
+#
+
+
+adapter driver ftdi
+ftdi_device_desc "Opella-LD Debug Probe"
+ftdi_vid_pid 0x0B6B 0x0040
+ftdi_tdo_sample_edge falling
+ftdi_layout_init 0x0A68 0xFF7B
+ftdi_channel 0
+ftdi_layout_signal JTAGOE -ndata 0x0010
+ftdi_layout_signal nTRST -data 0x0020
+ftdi_layout_signal nSRST -data 0x0040
+ftdi_layout_signal SWD_EN -data 0x0100
+ftdi_layout_signal SWDIO_OE -data 0x0200
+ftdi_layout_signal LED -ndata 0x0800
+transport select jtag
+

--- a/tcl/interface/ftdi/ashling-opella-ld-riscv-cjtag.cfg
+++ b/tcl/interface/ftdi/ashling-opella-ld-riscv-cjtag.cfg
@@ -1,0 +1,26 @@
+#
+# Ashling Opella-LD
+#
+# https://www.ashling.com/Opella-LD/
+#
+
+
+adapter driver ftdi
+ftdi_device_desc "Opella-LD Debug Probe"
+ftdi_vid_pid 0x0B6B 0x0040
+ftdi_tdo_sample_edge falling
+ftdi_layout_init 0x0A68 0xFF7B
+ftdi_channel 0
+ftdi_layout_signal JTAGOE -ndata 0x0010
+ftdi_layout_signal nTRST -data 0x0020
+ftdi_layout_signal nSRST -data 0x0040
+ftdi_layout_signal SWD_EN -data 0x0100
+ftdi_layout_signal SWDIO_OE -data 0x0200
+ftdi_layout_signal LED -ndata 0x0800
+ftdi_layout_signal TCK -data 0x0001
+ftdi_layout_signal TDI -data 0x0002
+ftdi_layout_signal TDO -input 0x0004
+ftdi_layout_signal TMS -data 0x0008
+transport select cjtag
+
+


### PR DESCRIPTION
Adding Opella-LD cJTAG support. The existing support for the Olimex cJTAG support will be broken with the addition. There will be no changes for the JTAG connections.